### PR TITLE
chore: Updated CurlFramework, making it easier to switch to full version

### DIFF
--- a/Scripts/CurlFramework.sh
+++ b/Scripts/CurlFramework.sh
@@ -2,9 +2,10 @@
 
 # The version of Xcode you want to fetch the framework for.
 # If you need a given version built for you let us know.
-# Our CI Servers build for XCode 9.# by default.
+# Our CI Servers build for XCode 9.#-10.0 by default.
 
 #This directory has to match up with your Framework Search paths in XCode Build Configuration.
+
 FRAMEWORK_DIR=./Framework/Release
 
 #Ensure it exists and change to it.
@@ -21,50 +22,52 @@ fi
 
 if [ "$XCODE_VERSION" = "Xcode9.3.1" ]; then
     XCODE_VERSION = "Xcode9.3"
-fi 
+fi
 
 if [ "$XCODE_VERSION" = "Xcode9.4.1" ]; then
     XCODE_VERSION="Xcode9.4"
 fi 
 
-if [[ -z "${DEQUE_ATTEST_LIBRARY_NAME}" ]]; then
-    LIBRARY="AttestIOSFree"
-else
-    LIBRARY=$DEQUE_ATTEST_LIBRARY_NAME
-fi
-
 ATTEST_FRAMEWORK_VERSION=${DEQUE_ATTEST_IOS_VERSION}
 
 if [ -z "$ATTEST_FRAMEWORK_VERSION" ]; then
-    echo "No Attest IOS Framework version set.  Please set the environment variable \${DEQUE_ATTEST_IOS_VERSION} in your Bash profile. A list of framework versions is available at https://www.github.com/dequelabs/Worldspace-for-iOS/releases"
+    echo "No Attest IOS Framework version set.  Please set the environment variable \${DEQUE_ATTEST_IOS_VERSION} in your Bash profile. A list of framework versions is available at https://www.github.com/dequelabs/Deque-University-for-iOS/wiki/Releases"
     exit 1
 fi
 
 if [ -z "${DEQUE_ANON_APIKEY}" ]; then
-    echo "No API key found to retrieve the Attest IOS Framework.  In your Bash profile, please set the environment variable \${DEQUE_ANON_APIKEY} to be the API key that you have been emailed. See https://www.github.com/dequelabs/Worldspace-for-iOS for more information."
+    echo "No API key found to retrieve the Attest IOS Framework.  In your Bash profile, please set the environment variable \${DEQUE_ANON_APIKEY} to be the API key that you have been emailed. See https://www.github.com/dequelabs/Deque-University-for-iOS/wiki/Getting-Started for more information."
     exit 1
 fi
 
-if [ $LIBRARY != "AttestIOSFree" ] && [ $LIBRARY != "Attest-iOS" ]; then
-    echo "The only available options for the DEQUE_ATTEST_LIBRARY_NAME variable  are \"AttestIOSFree\" and \"Attest-iOS\". The current value for this variable is $LIBRARY."
-    exit 1
-fi
-
-#Fetch the library zip with our anonymous api key.
+#Try fetching full version.
 curl -s -H "X-JFrog-Art-Api: ${DEQUE_ANON_APIKEY}" \
-	-O "https://agora.dequecloud.com/artifactory/$LIBRARY/framework/$XCODE_VERSION/Attest.framework-$ATTEST_FRAMEWORK_VERSION.zip"
+    -O "https://agora.dequecloud.com/artifactory/Attest-iOS/framework/$XCODE_VERSION/Attest.framework-$ATTEST_FRAMEWORK_VERSION.zip"
 
-#Unzip whatever version was fetched
+#Try unzipping full version of framework
 if unzip Attest.framework-$ATTEST_FRAMEWORK_VERSION.zip &> /dev/null; then
-    echo "Attest Successfully Fetched"
-else 
+    echo "Full Version of Attest Successfully Fetched"
+    exit 0
+fi
+
+rm -rf Framework
+
+curl -s -H "X-JFrog-Art-Api: ${DEQUE_ANON_APIKEY}" \
+    -O "https://agora.dequecloud.com/artifactory/AttestIOSFree/framework/$XCODE_VERSION/Attest.framework-$ATTEST_FRAMEWORK_VERSION.zip"
+
+#Try unzipping free version of framework
+if unzip Attest.framework-$ATTEST_FRAMEWORK_VERSION.zip &> /dev/null; then
+    echo "Free Version of Attest Successfully Fetched"
+    exit 0
+else
+    LIBRARY="AttestIOSFree"
     echo "Attest Failed to Download"
     echo "\"$XCODE_VERSION\" should match one of the URIs below (Except the /)"
         curl -s -H "X-JFrog-Art-Api: ${DEQUE_ANON_APIKEY}" "https://agora.dequecloud.com/artifactory/api/storage/$LIBRARY/framework/"
     
     echo ""
 
-    echo "If your extact Xcode version isn't available you can override this in your bash_profile."
+    echo "If your exact Xcode version isn't available you can override this in your bash_profile."
     echo "For example for Xcode 9.3.1 a proper bash_profile entry would be"
     echo ""
     echo "export DEQUE_ATTEST_XCODE_VERSION=Xcode9.3"


### PR DESCRIPTION
Instead of two separate API key variables (as requested in #40), I changed the CurlFramework script to use only the `DEQUE_ANON_APIKEY` variable. This way, users can just change this variable when they have access to the full version.  No separate variable to specify full vs free is needed.